### PR TITLE
add prefetch prop and make it false

### DIFF
--- a/src/components/AnimeCard.tsx
+++ b/src/components/AnimeCard.tsx
@@ -103,6 +103,7 @@ const AnimeCard: React.FC<AnimeCardProps> = ({ ani }) => {
           <Link
             href="/anime/[id]"
             as={`/anime/${ani.mal_id}`}
+            prefetch={false}
             className="flex w-full items-center justify-center p-2 duration-150 hover:text-pink-400 hover:ease-in"
           >
             <FaInfoCircle className="text-xl" />


### PR DESCRIPTION
NextJS prefetches the <Link> element on default. So when I was hovering each AnimeCard is made a network request, which eventually made the API rate limited from the hovering. 
- Add the prefetch prop on Link in AnimeCard.tsx and make it false.